### PR TITLE
add ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+host_key_checking       = False
+retry_files_enabled     = False
+callback_whitelist      = profile_tasks
+forks                   = 20


### PR DESCRIPTION
This disables .retry files and adds timestamps in the ansible-playbook output.